### PR TITLE
feat: 新增 APPLEPAY 於 trade_info 支援清單

### DIFF
--- a/lib/offsite_payments/integrations/spgateway/trade_info.rb
+++ b/lib/offsite_payments/integrations/spgateway/trade_info.rb
@@ -27,6 +27,7 @@ module OffsitePayments
           CreditRed
           CREDITAE
           ANDROIDPAY
+          APPLEPAY
           SAMSUNGPAY
           ESUNWALLET
           TAIWANPAY


### PR DESCRIPTION
## Summary

- 在 `trade_info.rb` 的行動支付方式清單中新增 `APPLEPAY`

## Test plan

- [ ] 確認 `APPLEPAY` 出現在 `trade_info` 支援的付款方式清單中
- [ ] 確認其他付款方式（`ANDROIDPAY`、`SAMSUNGPAY` 等）不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)